### PR TITLE
Improvement: Removed unnecessary ContractsAssemblyMarker.cs class

### DIFF
--- a/StudentFiles/StudentFiles.Api/Program.cs
+++ b/StudentFiles/StudentFiles.Api/Program.cs
@@ -6,7 +6,6 @@ namespace StudentFiles.Api
     using StudentFiles.Api.Configuration;
     using StudentFiles.Api.Services;
     using StudentFiles.Application;
-    using StudentFiles.Contracts;
     using StudentFiles.Infrastructure.Data.Repositories.Course;
     using StudentFiles.Infrastructure.Data.Repositories.Grade;
     using StudentFiles.Infrastructure.Data.Repositories.User;
@@ -35,7 +34,7 @@ namespace StudentFiles.Api
             builder.Services.AddMediatR(configuration: cfg =>
             {
                 cfg.RegisterGenericHandlers = true;
-                cfg.RegisterServicesFromAssemblies(typeof(ContractsAssemblyMarker).Assembly, typeof(ApplicationAssemblyMarker).Assembly);
+                cfg.RegisterServicesFromAssemblies(typeof(ApplicationAssemblyMarker).Assembly);
             });
 
             builder.Services.AddScoped<IUserRepository, UserRepository>();

--- a/StudentFiles/StudentFiles.Contracts/ContractsAssemblyMarker.cs
+++ b/StudentFiles/StudentFiles.Contracts/ContractsAssemblyMarker.cs
@@ -1,4 +1,0 @@
-﻿namespace StudentFiles.Contracts
-{
-    public class ContractsAssemblyMarker { }
-}


### PR DESCRIPTION
This pull request removes the unnecessary ContractsAssemblyMarker, which was probably a leftover of the old implementation.